### PR TITLE
Move ToS and privacy policy to new page layout

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,9 @@
+---
+layout: base
+---
+<section class="jumbotron bg-white mb-4 rounded-0">
+    <div class="container">
+        <h1 class="jumbotron-heading">{{ page.title }}</h1>
+        {{ content }}
+    </div>
+</section>

--- a/privacy.html
+++ b/privacy.html
@@ -1,3 +1,6 @@
+---
+layout: page
+---
 <div style="border: 2px solid green; padding: 20px;"><center><strong>Privacy Notice</strong></center>
 <p>Thanks for taking the time to review this document. Like you, we are concerned with the safety of your personal information. This privacy notice discloses the privacy practices for <a href="http://www.northendmakers.org">North End Makers</a>. This privacy notice applies solely to information collected by this website. It will notify you of the following:</p>
 <ol type="1">

--- a/tos.html
+++ b/tos.html
@@ -1,3 +1,6 @@
+---
+layout: page
+---
 <h2>North End Makers Terms of Service</h2>
 <h3>1. Terms</h3>
 <p>By accessing the website at <a href="http://www.northendmakers.org">http://www.northendmakers.org</a>, you are agreeing to be bound by these terms of service, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this website are protected by applicable copyright and trademark law.</p>


### PR DESCRIPTION
Wrap the terms of service and privacy policy page with the main website header/footer.