### PR TITLE
Add redirects from *.php pages so existing links will continue to work

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,11 +27,14 @@ url: "https://northendmakers.org"
 twitter_username: northendmakers
 github_username:  NorthEndMakerspace
 
+# Remove the .html extension from URLs
+permalink: pretty
 
 # Build settings
 plugins:
   - jekyll-feed
   - jekyll_picture_tag
+  - jekyll-redirect-from
 
 picture:
   suppress_warnings: true

--- a/about.html
+++ b/about.html
@@ -3,6 +3,7 @@ layout: base
 title: 'Nonprofit Information on North End Makerspace in Seattle, WA'
 description: 'Join a nonprofit makerspace in the north end of the greater Seattle area. We are an inclusive community
 who get together to learn, share, and grow.'
+redirect_from: [/about.php/] # Legacy PHP redirect (#18)
 ---
 <section class="jumbotron bg-white text-center rounded-0">
   <div class="container">

--- a/community.html
+++ b/community.html
@@ -16,6 +16,7 @@ images:
 - images/grams/gram10.png
 - images/grams/gram11.png
 - images/grams/gram12.png
+redirect_from: [/community.php/] # Legacy PHP redirect (#18)
 ---
 <section class="jumbotron text-center mb-4 rounded-0">
   <div class="container">

--- a/conduct.html
+++ b/conduct.html
@@ -3,6 +3,7 @@ layout: base
 title: 'Code of Conduct for North End Makerspace in Seattle, WA'
 description: 'Join a nonprofit makerspace in the north end of the greater Seattle area. We are an inclusive community
 who get together to learn, share, and grow.'
+redirect_from: [/conduct.php/] # Legacy PHP redirect (#18)
 ---
 <section class="jumbotron bg-white mb-0 rounded-0">
   <div class="container">

--- a/donate.html
+++ b/donate.html
@@ -4,6 +4,7 @@ title: 'Donate to North End Makerspace in Seattle, WA'
 description: 'Donate to a nonprofit makerspace in the north end of the greater Seattle area. We are an inclusive
 community who get
 together to learn, share, and grow.'
+redirect_from: [/donate.php/] # Legacy PHP redirect (#18)
 ---
 <section class="jumbotron text-center mb-4 rounded-0">
   <div class="container">

--- a/events.html
+++ b/events.html
@@ -3,6 +3,7 @@ layout: base
 title: 'Attend an Event at North End Makerspace in Seattle, WA'
 description: 'Join a nonprofit makerspace in the north end of the greater Seattle area. We are an inclusive community
 who get together to learn, share, and grow.'
+redirect_from: [/events.php/] # Legacy PHP redirect (#18)
 ---
 <section class="jumbotron text-center mb-4 rounded-0">
   <div class="container">

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@ gallery_images:
 - images/gallery/08.jpg
 - images/gallery/10.jpg
 - images/gallery/11.jpg
+redirect_from: [/index.php/] # Legacy PHP redirect (#18)
 ---
 <div class="mb-0">
     <style>

--- a/join.html
+++ b/join.html
@@ -2,6 +2,7 @@
 layout: base
 title: 'Join the North End Makerspace in Seattle, WA'
 description: 'Join a nonprofit makerspace in the north end of the greater Seattle area. We are an inclusive community who get together to learn, share, and grow.'
+redirect_from: [/join.php/] # Legacy PHP redirect (#18)
 ---
 <section class="jumbotron text-center mb-4 rounded-0">
   <div class="container">

--- a/privacy.html
+++ b/privacy.html
@@ -1,3 +1,6 @@
+---
+redirect_from: [/privacy.php/] # Legacy PHP redirect (#18)
+---
 <div style="border: 2px solid green; padding: 20px;"><center><strong>Privacy Notice</strong></center>
 <p>Thanks for taking the time to review this document. Like you, we are concerned with the safety of your personal information. This privacy notice discloses the privacy practices for <a href="http://www.northendmakers.org">North End Makers</a>. This privacy notice applies solely to information collected by this website. It will notify you of the following:</p>
 <ol type="1">

--- a/tool-training.html
+++ b/tool-training.html
@@ -2,6 +2,7 @@
 layout: base
 title: 'Tool Training at North End Makerspace in Seattle, WA'
 description: 'Explore the tool training available at North End Makerspace.'
+redirect_from: [/tool-training.php/] # Legacy PHP redirect (#18)
 ---
 <section class="jumbotron text-center mb-4 rounded-0">
   <div class="container">

--- a/tos.html
+++ b/tos.html
@@ -1,3 +1,6 @@
+---
+redirect_from: [/tos.php/] # Legacy PHP redirect (#18)
+---
 <h2>North End Makers Terms of Service</h2>
 <h3>1. Terms</h3>
 <p>By accessing the website at <a href="http://www.northendmakers.org">http://www.northendmakers.org</a>, you are agreeing to be bound by these terms of service, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this website are protected by applicable copyright and trademark law.</p>

--- a/visit.html
+++ b/visit.html
@@ -3,6 +3,7 @@ layout: base
 title: 'Visit North End Makerspace in Seattle, WA'
 description: 'Join a nonprofit makerspace in the north end of the greater Seattle area. We are an inclusive community
 who get together to learn, share, and grow.'
+redirect_from: [/visit.php/] # Legacy PHP redirect (#18)
 ---
 <section class="jumbotron text-center mb-4 rounded-0">
   <div class="container">

--- a/volunteer.html
+++ b/volunteer.html
@@ -3,6 +3,7 @@ layout: base
 title: 'Volunteer for North End Makerspace in Seattle, WA'
 description: 'Join a nonprofit makerspace in the north end of the greater Seattle area. We are an inclusive community
 who get together to learn, share, and grow.'
+redirect_from: [/volunteer.php/] # Legacy PHP redirect (#18)
 ---
 <section class="jumbotron bg-white text-center mb-4 rounded-0">
   <div class="container">


### PR DESCRIPTION
The `redirect_from` entries need to have a trailing `/` so Jekyll will create a folder containing an index.html file. This makes a fake php "file" instead of actually trying to serve a php file.

This also sets the permalink format to exclude the file extension.

Fixes: #18